### PR TITLE
add case for linux aarch64 (arm64) architecture

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,7 +41,7 @@ get_arch() {
       echo "amd64"
       ;;
 
-    arm64)
+    arm64 | aarch64)
       echo "arm64_static"
       ;;
 


### PR DESCRIPTION
Update case statement to handle Linux arm64 architecture return from `uname -m` of `aarch64`.

Related to Issue #2 